### PR TITLE
Resolve issue causing inaccurate dumping of PE when the size of raw P…

### DIFF
--- a/CAPE/CAPE.c
+++ b/CAPE/CAPE.c
@@ -2149,7 +2149,7 @@ int ScanForDisguisedPE(PVOID Buffer, SIZE_T Size, PVOID* Offset)
 		Size = AccessibleSize;
 
 	// we want to stop short of the max look-ahead in IsDisguisedPEHeader
-	for (p=0; p < Size - SystemInfo.dwPageSize; p++)
+	for (p=0; p <= Size - SystemInfo.dwPageSize ; p++)
 	{
 		RetVal = IsDisguisedPEHeader((PVOID)((BYTE*)Buffer+p));
 


### PR DESCRIPTION
…E is equal to dwPageSize

Fix: Resolve issue causing inaccurate dumping of PE when the size of raw PE is equal to dwPageSize

In the existing code, a bug was identified that led to incorrect dumping of Compressed payload when the size of the raw PE equaled ``dwPageSize``. The flaw originated from a previous author's use of the '<' operator in the loop comparison. Specifically, the condition failed to account for the scenario where ```Size``` equaled ```dwPageSize```, resulting in the loop for ```IsDisguisedPEHeader``` not being executed.

During testing, a notable case involved the Upatre malware (SHA-256: aab0b3139a1a96a72562d436efa1b47d). The dump obtained after running the test revealed inaccuracies in the output. Furthermore, Cape managed to perform the dump, but the result was invalid. With the introduction of the provided patch, the issue was successfully addressed, and the dumping process now functions flawlessly.

This commit rectifies the aforementioned bug and ensures accurate PE dumping even when `Size` equals `dwPageSize`.

Dump is triggered after a call to RtlDecompressBuffer Trace log after patch
```


PID = 4052 Client: DEBUG:4052: RtlDecompressBuffer hook: scanning region 0x400000 size 0x1000.


PID = 4052 Client: DEBUG:4052: GetAccessibleSize: Accessible size = 32768

PID = 4052 Client: DEBUG:4052: GetAccessibleSize: Accessible size = 950272

PID = 4052 Client: DEBUG:4052: GetAccessibleSize: AddressOfPage= 408000 , OriginalAllocationBase = 400000

PID = 4052 Client: DEBUG:4052: DumpPEsInRange: ReverseScanForNonZero size 4096!


PID = 4052 Client: DEBUG:4052: DumpPEsInRange: Scanning range 0x00400000 - 0x00401000.


PID = 4052 Client: DEBUG:4052: ScanForDisguisedPE: PE image located at: 0x00400000


PID = 4052 Client: DEBUG:4052: DumpImageInCurrentProcess: Attempting to dump 'raw' PE image (process 4052)


PID = 4052 Client: DEBUG:4052: DumpPE: Instantiating PeParser with address: 0x00400000.

```